### PR TITLE
Fix as per 3.6 changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
     %s = trytond.modules.%s
     """ % (module_name, module_name),
     tests_require=[
-        'mock',
+        'moto',
     ],
     test_suite='tests',
     cmdclass={

--- a/static_file.py
+++ b/static_file.py
@@ -174,7 +174,7 @@ class NereidStaticFile:
         bucket = self.folder.get_bucket()
         s3key = key.Key(bucket)
         s3key.key = self.s3_key
-        return s3key.set_contents_from_string(value[:])
+        return s3key.set_contents_from_string(bytes(value))
 
     def get_file_binary(self, name):
         '''
@@ -197,7 +197,7 @@ class NereidStaticFile:
                 # TODO: make the size configurable
                 return
             try:
-                return buffer(s3key.get_contents_as_string())
+                return fields.Binary.cast(s3key.get_contents_as_string())
             except exception.S3ResponseError as error:
                 if error.status == 404:
                     with Transaction().new_cursor(readonly=False) as txn:

--- a/tests/test_nereid_s3.py
+++ b/tests/test_nereid_s3.py
@@ -18,10 +18,8 @@ if os.path.isdir(DIR):
 
 import unittest
 
-from mock import patch
-from boto.s3 import connection
-from boto.s3.bucket import Bucket
-from boto.s3.key import Key
+import boto
+from moto import mock_s3
 import trytond.tests.test_tryton
 from trytond.tests.test_tryton import (
     POOL, DB_NAME, USER, CONTEXT, ModuleTestCase
@@ -31,7 +29,7 @@ from trytond.config import config
 
 config.set('nereid_s3', 's3_access_key', 'ABCD')
 config.set('nereid_s3', 's3_secret_key', '123XYZ')
-config.set('nereid_s3', 's3_bucket_name', 'tryton-test-s3')
+config.set('nereid_s3', 'bucket', 'tryton-test-s3')
 
 
 class TestNereidS3(ModuleTestCase):
@@ -46,34 +44,15 @@ class TestNereidS3(ModuleTestCase):
         self.static_file = POOL.get('nereid.static.file')
         self.static_folder = POOL.get('nereid.static.folder')
 
-        # Mock S3Connection
-        self.s3_api_patcher = patch(
-            'boto.s3.connection.S3Connection', autospec=True
-        )
-        PatchedS3 = self.s3_api_patcher.start()
+        self.mock = mock_s3()
+        self.mock.start()
 
-        # Mock S3Key
-        self.s3_key_patcher = patch(
-            'boto.s3.key.Key', autospec=True
-        )
-        PatchedS3Key = self.s3_key_patcher.start()
-
-        PatchedS3.return_value = connection.S3Connection('ABCD', '123XYZ')
-        PatchedS3.return_value.get_bucket = lambda bucket_name: Bucket(
-            PatchedS3.return_value, 'tryton-test-s3'
-        )
-
-        PatchedS3Key.return_value = Key(
-            Bucket(PatchedS3.return_value, 'tryton-test-s3'), 'some key'
-        )
-        PatchedS3Key.return_value.key = "some key"
-        PatchedS3Key.return_value.get_contents_as_string = lambda *a: 'testfile'
-        PatchedS3Key.return_value.set_contents_from_string = \
-            lambda value: 'testfile'
+        # Create test bucket to save s3 data
+        conn = boto.connect_s3()
+        conn.create_bucket(config.get('nereid_s3', 'bucket'))
 
     def tearDown(self):
-        self.s3_api_patcher.stop()
-        self.s3_key_patcher.stop()
+        self.mock.stop()
 
     def test0010_static_file(self):
         """


### PR DESCRIPTION
* Binary fields work on bytesarray but boto only understand bytes
* Cast binary file content